### PR TITLE
New version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           submodules: recursive
       - name: Install npm dependencies
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: npm install
       - name: "Generate file SH IF LAST"
         timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,6 @@ jobs:
         timeout-minutes: 60
         if: matrix.php.disable == 'off'
         run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }}
-      - name: "Show build image"
-        timeout-minutes: 60
-        if: matrix.php.disable == 'off'
-        run: cat build-php-${{ matrix.php.version }}.sh
       - name: "Build image"
         timeout-minutes: 60
         if: matrix.php.disable == 'off'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,23 +49,18 @@ jobs:
           submodules: recursive
       - name: Install npm dependencies
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: npm install
       - name: "Generate file SH IF LAST"
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }} --select=phpfpm
       - name: "Build image PHP FPM"
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: ./build-php-fpm-${{ matrix.php.version }}.sh
       - name: "TAG image PHP FPM"
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: ./tag-php-fpm-${{ matrix.php.version }}.sh
       - name: "Show images"
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: npm run docker:image:ls
       - name: Set up QEMU
         if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'
@@ -97,23 +92,18 @@ jobs:
           submodules: recursive
       - name: Install npm dependencies
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: npm install
       - name: "Generate file SH IF LAST"
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }} --select=apache
       - name: "Build image PHP APACHE"
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: ./build-php-apache-${{ matrix.php.version }}.sh
       - name: "TAG image PHP APACHE"
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: ./tag-php-apache-${{ matrix.php.version }}.sh
       - name: "Show images"
         timeout-minutes: 60
-        if: matrix.php.disable == 'off'
         run: npm run docker:image:ls
       - name: Set up QEMU
         if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,18 +49,23 @@ jobs:
           submodules: recursive
       - name: Install npm dependencies
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: npm install
       - name: "Generate file SH IF LAST"
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }} --select=phpfpm
       - name: "Build image PHP FPM"
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: ./build-php-fpm-${{ matrix.php.version }}.sh
       - name: "TAG image PHP FPM"
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: ./tag-php-fpm-${{ matrix.php.version }}.sh
       - name: "Show images"
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: npm run docker:image:ls
       - name: Set up QEMU
         if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'
@@ -92,18 +97,23 @@ jobs:
           submodules: recursive
       - name: Install npm dependencies
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: npm install
       - name: "Generate file SH IF LAST"
+        if: matrix.php.disable == 'off'
         timeout-minutes: 60
         run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }} --select=apache
       - name: "Build image PHP APACHE"
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: ./build-php-apache-${{ matrix.php.version }}.sh
       - name: "TAG image PHP APACHE"
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: ./tag-php-apache-${{ matrix.php.version }}.sh
       - name: "Show images"
         timeout-minutes: 60
+        if: matrix.php.disable == 'off'
         run: npm run docker:image:ls
       - name: Set up QEMU
         if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
         uses: zoexx/github-action-json-file-properties@release
         with:
             file_path: "matrix.json"
-  php:
+  phpfpm:
     strategy:
       fail-fast: false
       matrix: 
         php: ${{ fromJson(needs.generatejobs.outputs.php) }}
-    name: PHP ${{ matrix.php.version }}
+    name: PHP FPM ${{ matrix.php.version }}
     needs: generatejobs
     runs-on: ubuntu-22.04
     steps:
@@ -54,7 +54,7 @@ jobs:
       - name: "Generate file SH IF LAST"
         timeout-minutes: 60
         if: matrix.php.disable == 'off'
-        run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }}
+        run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }} --select=phpfpm
       - name: "Build image PHP FPM"
         timeout-minutes: 60
         if: matrix.php.disable == 'off'
@@ -67,6 +67,42 @@ jobs:
         timeout-minutes: 60
         if: matrix.php.disable == 'off'
         run: npm run docker:image:ls
+      - name: Set up QEMU
+        if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push Docker
+        if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'
+        run: npm run docker:push:php
+  phpapache:
+    strategy:
+      fail-fast: false
+      matrix: 
+        php: ${{ fromJson(needs.generatejobs.outputs.php) }}
+    name: PHP APACHE${{ matrix.php.version }}
+    needs: generatejobs
+    runs-on: ubuntu-22.04
+    steps:
+      - name: cdout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install npm dependencies
+        timeout-minutes: 60
+        if: matrix.php.disable == 'off'
+        run: npm install
+      - name: "Generate file SH IF LAST"
+        timeout-minutes: 60
+        if: matrix.php.disable == 'off'
+        run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }} --select=apache
       - name: "Build image PHP APACHE"
         timeout-minutes: 60
         if: matrix.php.disable == 'off'
@@ -94,4 +130,6 @@ jobs:
       - name: Push Docker
         if: github.ref == 'refs/heads/main' && matrix.php.disable == 'off'
         run: npm run docker:push:php
+
+
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix: 
         php: ${{ fromJson(needs.generatejobs.outputs.php) }}
-    name: PHP APACHE${{ matrix.php.version }}
+    name: PHP APACHE ${{ matrix.php.version }}
     needs: generatejobs
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,26 @@ jobs:
         timeout-minutes: 60
         if: matrix.php.disable == 'off'
         run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }}
-      - name: "Build image"
+      - name: "Build image PHP FPM"
         timeout-minutes: 60
         if: matrix.php.disable == 'off'
-        run: ./build-php-${{ matrix.php.version }}.sh
+        run: ./build-php-fpm-${{ matrix.php.version }}.sh
+      - name: "TAG image PHP FPM"
+        timeout-minutes: 60
+        if: matrix.php.disable == 'off'
+        run: ./tag-php-fpm-${{ matrix.php.version }}.sh
+      - name: "Show images"
+        timeout-minutes: 60
+        if: matrix.php.disable == 'off'
+        run: npm run docker:image:ls
+      - name: "Build image PHP APACHE"
+        timeout-minutes: 60
+        if: matrix.php.disable == 'off'
+        run: ./build-php-apache-${{ matrix.php.version }}.sh
+      - name: "TAG image PHP APACHE"
+        timeout-minutes: 60
+        if: matrix.php.disable == 'off'
+        run: ./tag-php-apache-${{ matrix.php.version }}.sh
       - name: "Show images"
         timeout-minutes: 60
         if: matrix.php.disable == 'off'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
         timeout-minutes: 60
         if: matrix.php.disable == 'off'
         run: npm run docker:build:php --folder=${{ matrix.php.version }} --xdebug=${{ matrix.php.xdebug }} --latest=${{ matrix.php.latest }}
+      - name: "Show build image"
+        timeout-minutes: 60
+        if: matrix.php.disable == 'off'
+        run: cat build-php-${{ matrix.php.version }}.sh
       - name: "Build image"
         timeout-minutes: 60
         if: matrix.php.disable == 'off'

--- a/images/php-apache/5.6/Dockerfile
+++ b/images/php-apache/5.6/Dockerfile
@@ -55,10 +55,10 @@ FROM build-php-apache AS build-php-apache-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+FROM build-php-apache-wordpress AS build-php-apache-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
+FROM build-php-apache-symfony AS build-php-apache-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/5.6/Dockerfile
+++ b/images/php-apache/5.6/Dockerfile
@@ -32,20 +32,33 @@ RUN install-php-extensions \
     tidy \
     zip
 
-# Wordpress
-RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
-    chmod +x wp-cli.phar && \
-    mv wp-cli.phar /usr/local/bin/wp
-# Symfony
-RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
-    dpkg -i symfony-cli_amd64.deb && \
-    rm symfony-cli_amd64.deb
-
 WORKDIR /var/www
 
 EXPOSE 9000
 
 
+FROM build-php-apache AS build-php-apache-wordpress
+# Wordpress
+RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
+    chmod +x wp-cli.phar && \
+    mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-php-apache AS build-php-apache-symfony
+# Symfony
+RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
+    dpkg -i symfony-cli_amd64.deb && \
+    rm symfony-cli_amd64.deb
+    
+
 FROM build-php-apache AS build-php-apache-xdebug
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/7.4/Dockerfile
+++ b/images/php-apache/7.4/Dockerfile
@@ -55,10 +55,10 @@ FROM build-php-apache AS build-php-apache-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+FROM build-php-apache-wordpress AS build-php-apache-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
+FROM build-php-apache-symfony AS build-php-apache-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/7.4/Dockerfile
+++ b/images/php-apache/7.4/Dockerfile
@@ -32,20 +32,33 @@ RUN install-php-extensions \
     tidy \
     zip
 
-# Wordpress
-RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
-    chmod +x wp-cli.phar && \
-    mv wp-cli.phar /usr/local/bin/wp
-# Symfony
-RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
-    dpkg -i symfony-cli_amd64.deb && \
-    rm symfony-cli_amd64.deb
-
 WORKDIR /var/www
 
 EXPOSE 9000
 
 
+FROM build-php-apache AS build-php-apache-wordpress
+# Wordpress
+RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
+    chmod +x wp-cli.phar && \
+    mv wp-cli.phar /usr/local/bin/wp
+    
+
+FROM build-php-apache AS build-php-apache-symfony
+# Symfony
+RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
+    dpkg -i symfony-cli_amd64.deb && \
+    rm symfony-cli_amd64.deb
+    
+
 FROM build-php-apache AS build-php-apache-xdebug
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/8.0/Dockerfile
+++ b/images/php-apache/8.0/Dockerfile
@@ -32,20 +32,32 @@ RUN install-php-extensions \
     tidy \
     zip
 
-# Wordpress
-RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
-    chmod +x wp-cli.phar && \
-    mv wp-cli.phar /usr/local/bin/wp
-# Symfony
-RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
-    dpkg -i symfony-cli_amd64.deb && \
-    rm symfony-cli_amd64.deb
-
 WORKDIR /var/www
 
 EXPOSE 9000
 
+FROM build-php-apache AS build-php-apache-wordpress
+# Wordpress
+RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
+    chmod +x wp-cli.phar && \
+    mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-php-apache AS build-php-apache-symfony
+# Symfony
+RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
+    dpkg -i symfony-cli_amd64.deb && \
+    rm symfony-cli_amd64.deb
+    
 
 FROM build-php-apache AS build-php-apache-xdebug
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/8.0/Dockerfile
+++ b/images/php-apache/8.0/Dockerfile
@@ -54,10 +54,10 @@ FROM build-php-apache AS build-php-apache-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+FROM build-php-apache-wordpress AS build-php-apache-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
+FROM build-php-apache-symfony AS build-php-apache-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/8.1/Dockerfile
+++ b/images/php-apache/8.1/Dockerfile
@@ -32,20 +32,32 @@ RUN install-php-extensions \
     tidy \
     zip
 
-# Wordpress
-RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
-    chmod +x wp-cli.phar && \
-    mv wp-cli.phar /usr/local/bin/wp
-# Symfony
-RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
-    dpkg -i symfony-cli_amd64.deb && \
-    rm symfony-cli_amd64.deb
-
 WORKDIR /var/www
 
 EXPOSE 9000
 
+FROM build-php-apache AS build-php-apache-wordpress
+# Wordpress
+RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
+    chmod +x wp-cli.phar && \
+    mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-php-apache AS build-php-apache-symfony
+# Symfony
+RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
+    dpkg -i symfony-cli_amd64.deb && \
+    rm symfony-cli_amd64.deb
+    
 
 FROM build-php-apache AS build-php-apache-xdebug
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/8.1/Dockerfile
+++ b/images/php-apache/8.1/Dockerfile
@@ -54,10 +54,10 @@ FROM build-php-apache AS build-php-apache-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+FROM build-php-apache-wordpress AS build-php-apache-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
+FROM build-php-apache-symfony AS build-php-apache-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/8.2/Dockerfile
+++ b/images/php-apache/8.2/Dockerfile
@@ -32,20 +32,32 @@ RUN install-php-extensions \
     tidy \
     zip
 
-# Wordpress
-RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
-    chmod +x wp-cli.phar && \
-    mv wp-cli.phar /usr/local/bin/wp
-# Symfony
-RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
-    dpkg -i symfony-cli_amd64.deb && \
-    rm symfony-cli_amd64.deb
-
 WORKDIR /var/www
 
 EXPOSE 9000
 
+FROM build-php-apache AS build-php-apache-wordpress
+# Wordpress
+RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
+    chmod +x wp-cli.phar && \
+    mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-php-apache AS build-php-apache-symfony
+# Symfony
+RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
+    dpkg -i symfony-cli_amd64.deb && \
+    rm symfony-cli_amd64.deb
+    
 
 FROM build-php-apache AS build-php-apache-xdebug
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/8.2/Dockerfile
+++ b/images/php-apache/8.2/Dockerfile
@@ -54,10 +54,10 @@ FROM build-php-apache AS build-php-apache-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+FROM build-php-apache-wordpress AS build-php-apache-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
+FROM build-php-apache-symfony AS build-php-apache-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/8.3/Dockerfile
+++ b/images/php-apache/8.3/Dockerfile
@@ -32,20 +32,32 @@ RUN install-php-extensions \
     tidy \
     zip
 
-# Wordpress
-RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
-    chmod +x wp-cli.phar && \
-    mv wp-cli.phar /usr/local/bin/wp
-# Symfony
-RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
-    dpkg -i symfony-cli_amd64.deb && \
-    rm symfony-cli_amd64.deb
-
 WORKDIR /var/www
 
 EXPOSE 9000
 
+FROM build-php-apache AS build-php-apache-wordpress
+# Wordpress
+RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
+    chmod +x wp-cli.phar && \
+    mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-php-apache AS build-php-apache-symfony
+# Symfony
+RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
+    dpkg -i symfony-cli_amd64.deb && \
+    rm symfony-cli_amd64.deb
+    
 
 FROM build-php-apache AS build-php-apache-xdebug
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/php-apache/8.3/Dockerfile
+++ b/images/php-apache/8.3/Dockerfile
@@ -54,10 +54,10 @@ FROM build-php-apache AS build-php-apache-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-wordpress AS build-php-apache-xdebug-wordpress
+FROM build-php-apache-wordpress AS build-php-apache-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
-FROM build-php-apache-symfony AS build-php-apache-xdebug-symfony
+FROM build-php-apache-symfony AS build-php-apache-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/5.6/Dockerfile
+++ b/images/phpfpm/5.6/Dockerfile
@@ -54,11 +54,11 @@ FROM build-phpfpm AS build-phpfpm-xdebug
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+FROM build-phpfpm-wordpress AS build-phpfpm-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
+FROM build-phpfpm-symfony AS build-phpfpm-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/5.6/Dockerfile
+++ b/images/phpfpm/5.6/Dockerfile
@@ -32,18 +32,33 @@ RUN install-php-extensions \
     tidy \
     zip
 
+WORKDIR /var/www
+
+
+FROM build-phpfpm AS build-phpfpm-wordpress
 # Wordpress
 RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
     chmod +x wp-cli.phar && \
     mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-phpfpm AS build-phpfpm-symfony
 # Symfony
 RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
     dpkg -i symfony-cli_amd64.deb && \
     rm symfony-cli_amd64.deb
 
-WORKDIR /var/www
-
 
 FROM build-phpfpm AS build-phpfpm-xdebug
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/7.4/Dockerfile
+++ b/images/phpfpm/7.4/Dockerfile
@@ -54,11 +54,11 @@ FROM build-phpfpm AS build-phpfpm-xdebug
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+FROM build-phpfpm-wordpress AS build-phpfpm-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
+FROM build-phpfpm-symfony AS build-phpfpm-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/7.4/Dockerfile
+++ b/images/phpfpm/7.4/Dockerfile
@@ -32,18 +32,33 @@ RUN install-php-extensions \
     tidy \
     zip
 
+WORKDIR /var/www
+
+
+FROM build-phpfpm AS build-phpfpm-wordpress
 # Wordpress
 RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
     chmod +x wp-cli.phar && \
     mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-phpfpm AS build-phpfpm-symfony
 # Symfony
 RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
     dpkg -i symfony-cli_amd64.deb && \
     rm symfony-cli_amd64.deb
 
-WORKDIR /var/www
-
 
 FROM build-phpfpm AS build-phpfpm-xdebug
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/8.0/Dockerfile
+++ b/images/phpfpm/8.0/Dockerfile
@@ -54,11 +54,11 @@ FROM build-phpfpm AS build-phpfpm-xdebug
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+FROM build-phpfpm-wordpress AS build-phpfpm-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
+FROM build-phpfpm-symfony AS build-phpfpm-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/8.0/Dockerfile
+++ b/images/phpfpm/8.0/Dockerfile
@@ -32,18 +32,33 @@ RUN install-php-extensions \
     tidy \
     zip
 
+WORKDIR /var/www
+
+
+FROM build-phpfpm AS build-phpfpm-wordpress
 # Wordpress
 RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
     chmod +x wp-cli.phar && \
     mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-phpfpm AS build-phpfpm-symfony
 # Symfony
 RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
     dpkg -i symfony-cli_amd64.deb && \
     rm symfony-cli_amd64.deb
 
-WORKDIR /var/www
-
 
 FROM build-phpfpm AS build-phpfpm-xdebug
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/8.1/Dockerfile
+++ b/images/phpfpm/8.1/Dockerfile
@@ -54,11 +54,11 @@ FROM build-phpfpm AS build-phpfpm-xdebug
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+FROM build-phpfpm-wordpress AS build-phpfpm-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
+FROM build-phpfpm-symfony AS build-phpfpm-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/8.1/Dockerfile
+++ b/images/phpfpm/8.1/Dockerfile
@@ -32,18 +32,33 @@ RUN install-php-extensions \
     tidy \
     zip
 
+WORKDIR /var/www
+
+
+FROM build-phpfpm AS build-phpfpm-wordpress
 # Wordpress
 RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
     chmod +x wp-cli.phar && \
     mv wp-cli.phar /usr/local/bin/wp
+
+
+FROM build-phpfpm AS build-phpfpm-symfony
 # Symfony
 RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
     dpkg -i symfony-cli_amd64.deb && \
     rm symfony-cli_amd64.deb
 
-WORKDIR /var/www
-
 
 FROM build-phpfpm AS build-phpfpm-xdebug
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/8.2/Dockerfile
+++ b/images/phpfpm/8.2/Dockerfile
@@ -32,18 +32,32 @@ RUN install-php-extensions \
     tidy \
     zip
 
+WORKDIR /var/www
+
+
+FROM build-phpfpm AS build-phpfpm-wordpress
 # Wordpress
 RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
     chmod +x wp-cli.phar && \
     mv wp-cli.phar /usr/local/bin/wp
+
+FROM build-phpfpm AS build-phpfpm-symfony
 # Symfony
 RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
     dpkg -i symfony-cli_amd64.deb && \
     rm symfony-cli_amd64.deb
 
-WORKDIR /var/www
-
 
 FROM build-phpfpm AS build-phpfpm-xdebug
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/8.2/Dockerfile
+++ b/images/phpfpm/8.2/Dockerfile
@@ -53,11 +53,11 @@ FROM build-phpfpm AS build-phpfpm-xdebug
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+FROM build-phpfpm-wordpress AS build-phpfpm-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
+FROM build-phpfpm-symfony AS build-phpfpm-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/8.3/Dockerfile
+++ b/images/phpfpm/8.3/Dockerfile
@@ -32,18 +32,32 @@ RUN install-php-extensions \
     tidy \
     zip
 
+WORKDIR /var/www
+
+
+FROM build-phpfpm AS build-phpfpm-wordpress
 # Wordpress
 RUN wget https://github.com/wp-cli/wp-cli/releases/download/v2.9.0/wp-cli-2.9.0.phar -O wp-cli.phar && \
     chmod +x wp-cli.phar && \
     mv wp-cli.phar /usr/local/bin/wp
+
+FROM build-phpfpm AS build-phpfpm-symfony
 # Symfony
 RUN wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.7.3/symfony-cli_5.7.3_amd64.deb -O symfony-cli_amd64.deb && \
     dpkg -i symfony-cli_amd64.deb && \
     rm symfony-cli_amd64.deb
 
-WORKDIR /var/www
-
 
 FROM build-phpfpm AS build-phpfpm-xdebug
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+
+RUN install-php-extensions xdebug
+
+
+FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
 
 RUN install-php-extensions xdebug

--- a/images/phpfpm/8.3/Dockerfile
+++ b/images/phpfpm/8.3/Dockerfile
@@ -53,11 +53,11 @@ FROM build-phpfpm AS build-phpfpm-xdebug
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-wordpress AS build-phpfpm-xdebug-wordpress
+FROM build-phpfpm-wordpress AS build-phpfpm-wordpress-xdebug
 
 RUN install-php-extensions xdebug
 
 
-FROM build-phpfpm-symfony AS build-phpfpm-xdebug-symfony
+FROM build-phpfpm-symfony AS build-phpfpm-symfony-xdebug
 
 RUN install-php-extensions xdebug

--- a/main.js
+++ b/main.js
@@ -79,7 +79,7 @@ program
             `docker build -t koromerzhin/php:${versionimage}-fpm-xdebug build/phpfpm/${versionimage} --target build-phpfpm-xdebug`
           );
         }
-        if (getLatest(options) != 'undefined') {
+        if (getLatest(options) != 'on') {
           cmd.push(
             `docker image tag koromerzhin/php:${versionimage}-fpm koromerzhin/php:fpm-latest`
           );
@@ -126,7 +126,7 @@ program
             `docker build -t koromerzhin/php:${versionimage}-apache-symfony-xdebug build/php-apache/${versionimage} --target build-php-apache-symfony-xdebug`
           );
         }
-        if (getLatest(options) != undefined) {
+        if (getLatest(options) == 'on') {
           cmd.push(
             `docker image tag koromerzhin/php:${versionimage}-apache koromerzhin/php:apache-latest`
           );

--- a/main.js
+++ b/main.js
@@ -31,6 +31,15 @@ function getXdebug(options) {
   return xdebug;
 }
 
+function getSelect(options) {
+  const only =
+    process.env.npm_config_select != undefined
+      ? process.env.npm_config_select
+      : options.select;
+
+  return only;
+}
+
 function getVersions(folder) {
   const versions = fs
     .readdirSync(`images/${folder}`, { withFileTypes: true })
@@ -51,134 +60,139 @@ program
   .description("build php images")
   .option("--folder <folder>", "images version")
   .option("--latest", "latest")
+  .option("--select", "select")
   .action(async (options) => {
     const selectfolder = getSelectfolder(options);
-    cmdbuild = [];
-    cmdtag = [];
-    versions = getVersions("phpfpm");
-    versions.forEach((version) => {
-      let versionimage = setVersionImage(selectfolder, version);
-      if (
-        selectfolder == undefined ||
-        selectfolder == version ||
-        selectfolder.split(version).length - 1 == 1
-      ) {
-        cmdbuild.push(`mkdir -p build/phpfpm/${versionimage}`);
-        cmdbuild.push(
-          `cp images/phpfpm/${version}/Dockerfile build/phpfpm/${versionimage}/Dockerfile`
-        );
-        cmdbuild.push(
-          `sed -i 's/VERSIONIMAGE/php:${versionimage}-fpm/' build/phpfpm/${versionimage}/Dockerfile`
-        );
-        cmdbuild.push(
-          `docker build -t koromerzhin/php:${versionimage}-fpm build/phpfpm/${versionimage} --target build-phpfpm`
-        );
-        cmdbuild.push(
-          `docker build -t koromerzhin/php:${versionimage}-fpm-wordpress build/phpfpm/${versionimage} --target build-phpfpm-wordpress`
-        );
-        cmdbuild.push(
-          `docker build -t koromerzhin/php:${versionimage}-fpm-symfony build/phpfpm/${versionimage} --target build-phpfpm-symfony`
-        );
-        if (getXdebug(options) == 'on') {
+    if (getSelect(options) == 'phpfpm' || getSelect(options) == undefined) {
+      cmdbuild = [];
+      cmdtag = [];
+      versions = getVersions("phpfpm");
+      versions.forEach((version) => {
+        let versionimage = setVersionImage(selectfolder, version);
+        if (
+          selectfolder == undefined ||
+          selectfolder == version ||
+          selectfolder.split(version).length - 1 == 1
+        ) {
+          cmdbuild.push(`mkdir -p build/phpfpm/${versionimage}`);
           cmdbuild.push(
-            `docker build -t koromerzhin/php:${versionimage}-fpm-xdebug build/phpfpm/${versionimage} --target build-phpfpm-xdebug`
+            `cp images/phpfpm/${version}/Dockerfile build/phpfpm/${versionimage}/Dockerfile`
           );
           cmdbuild.push(
-            `docker build -t koromerzhin/php:${versionimage}-fpm-wordpress-xdebug build/phpfpm/${versionimage} --target build-phpfpm-wordpress-xdebug`
+            `sed -i 's/VERSIONIMAGE/php:${versionimage}-fpm/' build/phpfpm/${versionimage}/Dockerfile`
           );
           cmdbuild.push(
-            `docker build -t koromerzhin/php:${versionimage}-fpm-symfony-xdebug build/phpfpm/${versionimage} --target build-phpfpm-symfony-xdebug`
+            `docker build -t koromerzhin/php:${versionimage}-fpm build/phpfpm/${versionimage} --target build-phpfpm`
           );
-        }
-        if (getLatest(options) == 'on') {
-          cmdtag.push(
-            `docker image tag koromerzhin/php:${versionimage}-fpm koromerzhin/php:fpm-latest`
+          cmdbuild.push(
+            `docker build -t koromerzhin/php:${versionimage}-fpm-wordpress build/phpfpm/${versionimage} --target build-phpfpm-wordpress`
           );
-          cmdtag.push(
-            `docker image tag koromerzhin/php:${versionimage}-fpm-wordpress koromerzhin/php:fpm-wordpress-latest`
-          );
-          cmdtag.push(
-            `docker image tag koromerzhin/php:${versionimage}-fpm-symfony koromerzhin/php:fpm-symfony-latest`
+          cmdbuild.push(
+            `docker build -t koromerzhin/php:${versionimage}-fpm-symfony build/phpfpm/${versionimage} --target build-phpfpm-symfony`
           );
           if (getXdebug(options) == 'on') {
-            cmdtag.push(
-              `docker image tag koromerzhin/php:${versionimage}-fpm-wordpress-xdebug koromerzhin/php:fpm-latest-wordpress-xdebug`
+            cmdbuild.push(
+              `docker build -t koromerzhin/php:${versionimage}-fpm-xdebug build/phpfpm/${versionimage} --target build-phpfpm-xdebug`
             );
-            cmdtag.push(
-              `docker image tag koromerzhin/php:${versionimage}-fpm-symfony-xdebug koromerzhin/php:fpm-latest-symfony-xdebug`
+            cmdbuild.push(
+              `docker build -t koromerzhin/php:${versionimage}-fpm-wordpress-xdebug build/phpfpm/${versionimage} --target build-phpfpm-wordpress-xdebug`
             );
-            cmdtag.push(
-              `docker image tag koromerzhin/php:${versionimage}-fpm-xdebug koromerzhin/php:fpm-latest-xdebug`
+            cmdbuild.push(
+              `docker build -t koromerzhin/php:${versionimage}-fpm-symfony-xdebug build/phpfpm/${versionimage} --target build-phpfpm-symfony-xdebug`
             );
           }
+          if (getLatest(options) == 'on') {
+            cmdtag.push(
+              `docker image tag koromerzhin/php:${versionimage}-fpm koromerzhin/php:fpm-latest`
+            );
+            cmdtag.push(
+              `docker image tag koromerzhin/php:${versionimage}-fpm-wordpress koromerzhin/php:fpm-wordpress-latest`
+            );
+            cmdtag.push(
+              `docker image tag koromerzhin/php:${versionimage}-fpm-symfony koromerzhin/php:fpm-symfony-latest`
+            );
+            if (getXdebug(options) == 'on') {
+              cmdtag.push(
+                `docker image tag koromerzhin/php:${versionimage}-fpm-wordpress-xdebug koromerzhin/php:fpm-latest-wordpress-xdebug`
+              );
+              cmdtag.push(
+                `docker image tag koromerzhin/php:${versionimage}-fpm-symfony-xdebug koromerzhin/php:fpm-latest-symfony-xdebug`
+              );
+              cmdtag.push(
+                `docker image tag koromerzhin/php:${versionimage}-fpm-xdebug koromerzhin/php:fpm-latest-xdebug`
+              );
+            }
+          }
         }
-      }
-    });
-    saveInFile('build', cmdbuild, "fpm", selectfolder);
-    saveInFile('tag', cmdtag, "fpm", selectfolder);
-    cmdbuild = [];
-    cmdtag = [];
-    versions = getVersions("php-apache");
-    versions.forEach((version) => {
-      let versionimage = setVersionImage(selectfolder, version);
-      if (
-        selectfolder == undefined ||
-        selectfolder == version ||
-        selectfolder.split(version).length - 1 == 1
-      ) {
-        cmdbuild.push(`mkdir -p build/php-apache/${versionimage}`);
-        cmdbuild.push(
-          `cp images/php-apache/${version}/Dockerfile build/php-apache/${versionimage}/Dockerfile`
-        );
-        cmdbuild.push(
-          `sed -i 's/VERSIONIMAGE/php:${versionimage}-apache/' build/php-apache/${versionimage}/Dockerfile`
-        );
-        cmdbuild.push(
-          `docker build -t koromerzhin/php:${versionimage}-apache build/php-apache/${versionimage} --target build-php-apache`
-        );
-        cmdbuild.push(
-          `docker build -t koromerzhin/php:${versionimage}-apache-wordpress build/php-apache/${versionimage} --target build-php-apache-wordpress`
-        );
-        cmdbuild.push(
-          `docker build -t koromerzhin/php:${versionimage}-apache-symfony build/php-apache/${versionimage} --target build-php-apache-symfony`
-        );
-        if (getXdebug(options) == 'on') {
+      });
+      saveInFile('build', cmdbuild, "fpm", selectfolder);
+      saveInFile('tag', cmdtag, "fpm", selectfolder);
+    }
+    if (getSelect(options) == 'apache' || getSelect(options) == undefined) {
+      cmdbuild = [];
+      cmdtag = [];
+      versions = getVersions("php-apache");
+      versions.forEach((version) => {
+        let versionimage = setVersionImage(selectfolder, version);
+        if (
+          selectfolder == undefined ||
+          selectfolder == version ||
+          selectfolder.split(version).length - 1 == 1
+        ) {
+          cmdbuild.push(`mkdir -p build/php-apache/${versionimage}`);
           cmdbuild.push(
-            `docker build -t koromerzhin/php:${versionimage}-apache-xdebug build/php-apache/${versionimage} --target build-php-apache-xdebug`
+            `cp images/php-apache/${version}/Dockerfile build/php-apache/${versionimage}/Dockerfile`
           );
           cmdbuild.push(
-            `docker build -t koromerzhin/php:${versionimage}-apache-wordpress-xdebug build/php-apache/${versionimage} --target build-php-apache-wordpress-xdebug`
+            `sed -i 's/VERSIONIMAGE/php:${versionimage}-apache/' build/php-apache/${versionimage}/Dockerfile`
           );
           cmdbuild.push(
-            `docker build -t koromerzhin/php:${versionimage}-apache-symfony-xdebug build/php-apache/${versionimage} --target build-php-apache-symfony-xdebug`
+            `docker build -t koromerzhin/php:${versionimage}-apache build/php-apache/${versionimage} --target build-php-apache`
           );
-        }
-        if (getLatest(options) == 'on') {
-          cmdtag.push(
-            `docker image tag koromerzhin/php:${versionimage}-apache koromerzhin/php:apache-latest`
+          cmdbuild.push(
+            `docker build -t koromerzhin/php:${versionimage}-apache-wordpress build/php-apache/${versionimage} --target build-php-apache-wordpress`
           );
-          cmdtag.push(
-            `docker image tag koromerzhin/php:${versionimage}-apache-wordpress koromerzhin/php:apache-wordpress-latest`
-          );
-          cmdtag.push(
-            `docker image tag koromerzhin/php:${versionimage}-apache-symfony koromerzhin/php:apache-symfony-latest`
+          cmdbuild.push(
+            `docker build -t koromerzhin/php:${versionimage}-apache-symfony build/php-apache/${versionimage} --target build-php-apache-symfony`
           );
           if (getXdebug(options) == 'on') {
-            cmdtag.push(
-              `docker image tag koromerzhin/php:${versionimage}-apache-xdebug koromerzhin/php:apache-latest-xdebug`
+            cmdbuild.push(
+              `docker build -t koromerzhin/php:${versionimage}-apache-xdebug build/php-apache/${versionimage} --target build-php-apache-xdebug`
             );
-            cmdtag.push(
-              `docker image tag koromerzhin/php:${versionimage}-apache-wordpress-xdebug koromerzhin/php:apache-wordpress-latest-xdebug`
+            cmdbuild.push(
+              `docker build -t koromerzhin/php:${versionimage}-apache-wordpress-xdebug build/php-apache/${versionimage} --target build-php-apache-wordpress-xdebug`
             );
-            cmdtag.push(
-              `docker image tag koromerzhin/php:${versionimage}-apache-symfony-xdebug koromerzhin/php:apache-symfony-latest-xdebug`
+            cmdbuild.push(
+              `docker build -t koromerzhin/php:${versionimage}-apache-symfony-xdebug build/php-apache/${versionimage} --target build-php-apache-symfony-xdebug`
             );
           }
+          if (getLatest(options) == 'on') {
+            cmdtag.push(
+              `docker image tag koromerzhin/php:${versionimage}-apache koromerzhin/php:apache-latest`
+            );
+            cmdtag.push(
+              `docker image tag koromerzhin/php:${versionimage}-apache-wordpress koromerzhin/php:apache-wordpress-latest`
+            );
+            cmdtag.push(
+              `docker image tag koromerzhin/php:${versionimage}-apache-symfony koromerzhin/php:apache-symfony-latest`
+            );
+            if (getXdebug(options) == 'on') {
+              cmdtag.push(
+                `docker image tag koromerzhin/php:${versionimage}-apache-xdebug koromerzhin/php:apache-latest-xdebug`
+              );
+              cmdtag.push(
+                `docker image tag koromerzhin/php:${versionimage}-apache-wordpress-xdebug koromerzhin/php:apache-wordpress-latest-xdebug`
+              );
+              cmdtag.push(
+                `docker image tag koromerzhin/php:${versionimage}-apache-symfony-xdebug koromerzhin/php:apache-symfony-latest-xdebug`
+              );
+            }
+          }
         }
-      }
-    });
-    saveInFile('build', cmdbuild, "php-apache", selectfolder);
-    saveInFile('tag', cmdtag, "php-apache", selectfolder);
+      });
+      saveInFile('build', cmdbuild, "php-apache", selectfolder);
+      saveInFile('tag', cmdtag, "php-apache", selectfolder);
+    }
   });
 
 function saveInFile(type, cmd, image, selectfolder) {

--- a/main.js
+++ b/main.js
@@ -74,16 +74,40 @@ program
         cmd.push(
           `docker build -t koromerzhin/php:${versionimage}-fpm build/phpfpm/${versionimage} --target build-phpfpm`
         );
+        cmd.push(
+          `docker build -t koromerzhin/php:${versionimage}-fpm-wordpress build/phpfpm/${versionimage} --target build-phpfpm-wordpress`
+        );
+        cmd.push(
+          `docker build -t koromerzhin/php:${versionimage}-fpm-symfony build/phpfpm/${versionimage} --target build-phpfpm-symfony`
+        );
         if (getXdebug(options) == 'on') {
           cmd.push(
             `docker build -t koromerzhin/php:${versionimage}-fpm-xdebug build/phpfpm/${versionimage} --target build-phpfpm-xdebug`
           );
+          cmd.push(
+            `docker build -t koromerzhin/php:${versionimage}-fpm-wordpress-xdebug build/phpfpm/${versionimage} --target build-phpfpm-wordpress-xdebug`
+          );
+          cmd.push(
+            `docker build -t koromerzhin/php:${versionimage}-fpm-symfony-xdebug build/phpfpm/${versionimage} --target build-phpfpm-symfony-xdebug`
+          );
         }
-        if (getLatest(options) != 'on') {
+        if (getLatest(options) == 'on') {
           cmd.push(
             `docker image tag koromerzhin/php:${versionimage}-fpm koromerzhin/php:fpm-latest`
           );
+          cmd.push(
+            `docker image tag koromerzhin/php:${versionimage}-fpm-wordpress koromerzhin/php:fpm-wordpress-latest`
+          );
+          cmd.push(
+            `docker image tag koromerzhin/php:${versionimage}-fpm-symfony koromerzhin/php:fpm-symfony-latest`
+          );
           if (getXdebug(options) == 'on') {
+            cmd.push(
+              `docker image tag koromerzhin/php:${versionimage}-fpm-wordpress-xdebug koromerzhin/php:fpm-latest-wordpress-xdebug`
+            );
+            cmd.push(
+              `docker image tag koromerzhin/php:${versionimage}-fpm-symfony-xdebug koromerzhin/php:fpm-latest-symfony-xdebug`
+            );
             cmd.push(
               `docker image tag koromerzhin/php:${versionimage}-fpm-xdebug koromerzhin/php:fpm-latest-xdebug`
             );

--- a/main.js
+++ b/main.js
@@ -125,8 +125,8 @@ program
           }
         }
       });
-      saveInFile('build', cmdbuild, "fpm", selectfolder);
-      saveInFile('tag', cmdtag, "fpm", selectfolder);
+      saveInFile('build', cmdbuild, "php-fpm", selectfolder);
+      saveInFile('tag', cmdtag, "php-fpm", selectfolder);
     }
     if (getSelect(options) == 'apache' || getSelect(options) == undefined) {
       cmdbuild = [];

--- a/main.js
+++ b/main.js
@@ -109,18 +109,42 @@ program
         cmd.push(
           `docker build -t koromerzhin/php:${versionimage}-apache build/php-apache/${versionimage} --target build-php-apache`
         );
+        cmd.push(
+          `docker build -t koromerzhin/php:${versionimage}-apache-wordpress build/php-apache/${versionimage} --target build-php-apache-wordpress`
+        );
+        cmd.push(
+          `docker build -t koromerzhin/php:${versionimage}-apache-symfony build/php-apache/${versionimage} --target build-php-apache-symfony`
+        );
         if (getXdebug(options) == 'on') {
           cmd.push(
             `docker build -t koromerzhin/php:${versionimage}-apache-xdebug build/php-apache/${versionimage} --target build-php-apache-xdebug`
+          );
+          cmd.push(
+            `docker build -t koromerzhin/php:${versionimage}-apache-wordpress-xdebug build/php-apache/${versionimage} --target build-php-apache-wordpress-xdebug`
+          );
+          cmd.push(
+            `docker build -t koromerzhin/php:${versionimage}-apache-symfony-xdebug build/php-apache/${versionimage} --target build-php-apache-symfony-xdebug`
           );
         }
         if (getLatest(options) != undefined) {
           cmd.push(
             `docker image tag koromerzhin/php:${versionimage}-apache koromerzhin/php:apache-latest`
           );
+          cmd.push(
+            `docker image tag koromerzhin/php:${versionimage}-apache-wordpress koromerzhin/php:apache-wordpress-latest`
+          );
+          cmd.push(
+            `docker image tag koromerzhin/php:${versionimage}-apache-symfony koromerzhin/php:apache-symfony-latest`
+          );
           if (getXdebug(options) == 'on') {
             cmd.push(
               `docker image tag koromerzhin/php:${versionimage}-apache-xdebug koromerzhin/php:apache-latest-xdebug`
+            );
+            cmd.push(
+              `docker image tag koromerzhin/php:${versionimage}-apache-wordpress-xdebug koromerzhin/php:apache-wordpress-latest-xdebug`
+            );
+            cmd.push(
+              `docker image tag koromerzhin/php:${versionimage}-apache-symfony-xdebug koromerzhin/php:apache-symfony-latest-xdebug`
             );
           }
         }

--- a/main.js
+++ b/main.js
@@ -79,7 +79,7 @@ program
             `docker build -t koromerzhin/php:${versionimage}-fpm-xdebug build/phpfpm/${versionimage} --target build-phpfpm-xdebug`
           );
         }
-        if (getLatest(options) == 'on') {
+        if (getLatest(options) != 'undefined') {
           cmd.push(
             `docker image tag koromerzhin/php:${versionimage}-fpm koromerzhin/php:fpm-latest`
           );

--- a/main.js
+++ b/main.js
@@ -1,10 +1,7 @@
 const { program } = require("commander");
 const { exec } = require("child_process");
 let folder = "images";
-
-const fs = require("fs");
-let cmd = [];
-
+const fs   = require("fs");
 program.name("main.js").description("CLI to build image docker");
 
 function getSelectfolder(options) {
@@ -56,6 +53,8 @@ program
   .option("--latest", "latest")
   .action(async (options) => {
     const selectfolder = getSelectfolder(options);
+    cmdbuild = [];
+    cmdtag = [];
     versions = getVersions("phpfpm");
     versions.forEach((version) => {
       let versionimage = setVersionImage(selectfolder, version);
@@ -64,57 +63,61 @@ program
         selectfolder == version ||
         selectfolder.split(version).length - 1 == 1
       ) {
-        cmd.push(`mkdir -p build/phpfpm/${versionimage}`);
-        cmd.push(
+        cmdbuild.push(`mkdir -p build/phpfpm/${versionimage}`);
+        cmdbuild.push(
           `cp images/phpfpm/${version}/Dockerfile build/phpfpm/${versionimage}/Dockerfile`
         );
-        cmd.push(
+        cmdbuild.push(
           `sed -i 's/VERSIONIMAGE/php:${versionimage}-fpm/' build/phpfpm/${versionimage}/Dockerfile`
         );
-        cmd.push(
+        cmdbuild.push(
           `docker build -t koromerzhin/php:${versionimage}-fpm build/phpfpm/${versionimage} --target build-phpfpm`
         );
-        cmd.push(
+        cmdbuild.push(
           `docker build -t koromerzhin/php:${versionimage}-fpm-wordpress build/phpfpm/${versionimage} --target build-phpfpm-wordpress`
         );
-        cmd.push(
+        cmdbuild.push(
           `docker build -t koromerzhin/php:${versionimage}-fpm-symfony build/phpfpm/${versionimage} --target build-phpfpm-symfony`
         );
         if (getXdebug(options) == 'on') {
-          cmd.push(
+          cmdbuild.push(
             `docker build -t koromerzhin/php:${versionimage}-fpm-xdebug build/phpfpm/${versionimage} --target build-phpfpm-xdebug`
           );
-          cmd.push(
+          cmdbuild.push(
             `docker build -t koromerzhin/php:${versionimage}-fpm-wordpress-xdebug build/phpfpm/${versionimage} --target build-phpfpm-wordpress-xdebug`
           );
-          cmd.push(
+          cmdbuild.push(
             `docker build -t koromerzhin/php:${versionimage}-fpm-symfony-xdebug build/phpfpm/${versionimage} --target build-phpfpm-symfony-xdebug`
           );
         }
         if (getLatest(options) == 'on') {
-          cmd.push(
+          cmdtag.push(
             `docker image tag koromerzhin/php:${versionimage}-fpm koromerzhin/php:fpm-latest`
           );
-          cmd.push(
+          cmdtag.push(
             `docker image tag koromerzhin/php:${versionimage}-fpm-wordpress koromerzhin/php:fpm-wordpress-latest`
           );
-          cmd.push(
+          cmdtag.push(
             `docker image tag koromerzhin/php:${versionimage}-fpm-symfony koromerzhin/php:fpm-symfony-latest`
           );
           if (getXdebug(options) == 'on') {
-            cmd.push(
+            cmdtag.push(
               `docker image tag koromerzhin/php:${versionimage}-fpm-wordpress-xdebug koromerzhin/php:fpm-latest-wordpress-xdebug`
             );
-            cmd.push(
+            cmdtag.push(
               `docker image tag koromerzhin/php:${versionimage}-fpm-symfony-xdebug koromerzhin/php:fpm-latest-symfony-xdebug`
             );
-            cmd.push(
+            cmdtag.push(
               `docker image tag koromerzhin/php:${versionimage}-fpm-xdebug koromerzhin/php:fpm-latest-xdebug`
             );
           }
         }
       }
     });
+    saveInFile('build', cmdbuild, "fpm", selectfolder);
+    saveInFile('tag', cmdtag, "fpm", selectfolder);
+    cmdbuild = [];
+    cmdtag = [];
     versions = getVersions("php-apache");
     versions.forEach((version) => {
       let versionimage = setVersionImage(selectfolder, version);
@@ -123,62 +126,63 @@ program
         selectfolder == version ||
         selectfolder.split(version).length - 1 == 1
       ) {
-        cmd.push(`mkdir -p build/php-apache/${versionimage}`);
-        cmd.push(
+        cmdbuild.push(`mkdir -p build/php-apache/${versionimage}`);
+        cmdbuild.push(
           `cp images/php-apache/${version}/Dockerfile build/php-apache/${versionimage}/Dockerfile`
         );
-        cmd.push(
+        cmdbuild.push(
           `sed -i 's/VERSIONIMAGE/php:${versionimage}-apache/' build/php-apache/${versionimage}/Dockerfile`
         );
-        cmd.push(
+        cmdbuild.push(
           `docker build -t koromerzhin/php:${versionimage}-apache build/php-apache/${versionimage} --target build-php-apache`
         );
-        cmd.push(
+        cmdbuild.push(
           `docker build -t koromerzhin/php:${versionimage}-apache-wordpress build/php-apache/${versionimage} --target build-php-apache-wordpress`
         );
-        cmd.push(
+        cmdbuild.push(
           `docker build -t koromerzhin/php:${versionimage}-apache-symfony build/php-apache/${versionimage} --target build-php-apache-symfony`
         );
         if (getXdebug(options) == 'on') {
-          cmd.push(
+          cmdbuild.push(
             `docker build -t koromerzhin/php:${versionimage}-apache-xdebug build/php-apache/${versionimage} --target build-php-apache-xdebug`
           );
-          cmd.push(
+          cmdbuild.push(
             `docker build -t koromerzhin/php:${versionimage}-apache-wordpress-xdebug build/php-apache/${versionimage} --target build-php-apache-wordpress-xdebug`
           );
-          cmd.push(
+          cmdbuild.push(
             `docker build -t koromerzhin/php:${versionimage}-apache-symfony-xdebug build/php-apache/${versionimage} --target build-php-apache-symfony-xdebug`
           );
         }
         if (getLatest(options) == 'on') {
-          cmd.push(
+          cmdtag.push(
             `docker image tag koromerzhin/php:${versionimage}-apache koromerzhin/php:apache-latest`
           );
-          cmd.push(
+          cmdtag.push(
             `docker image tag koromerzhin/php:${versionimage}-apache-wordpress koromerzhin/php:apache-wordpress-latest`
           );
-          cmd.push(
+          cmdtag.push(
             `docker image tag koromerzhin/php:${versionimage}-apache-symfony koromerzhin/php:apache-symfony-latest`
           );
           if (getXdebug(options) == 'on') {
-            cmd.push(
+            cmdtag.push(
               `docker image tag koromerzhin/php:${versionimage}-apache-xdebug koromerzhin/php:apache-latest-xdebug`
             );
-            cmd.push(
+            cmdtag.push(
               `docker image tag koromerzhin/php:${versionimage}-apache-wordpress-xdebug koromerzhin/php:apache-wordpress-latest-xdebug`
             );
-            cmd.push(
+            cmdtag.push(
               `docker image tag koromerzhin/php:${versionimage}-apache-symfony-xdebug koromerzhin/php:apache-symfony-latest-xdebug`
             );
           }
         }
       }
     });
-    saveInFile(cmd, "php", selectfolder);
+    saveInFile('build', cmdbuild, "php-apache", selectfolder);
+    saveInFile('tag', cmdtag, "php-apache", selectfolder);
   });
 
-function saveInFile(cmd, image, selectfolder) {
-  let file = `build-${image}`;
+function saveInFile(type, cmd, image, selectfolder) {
+  let file = `${type}-${image}`;
   if (selectfolder != undefined) {
     file += `-${selectfolder}`;
   }

--- a/matrix.json
+++ b/matrix.json
@@ -3,157 +3,169 @@
     {
       "version": "5.6.40",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "7.4.12",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "7.4.33",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.0.15",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.0.27",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.0.29",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.1.6",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.1.11",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.1.13",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.1.20",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.0",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.1",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.2",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.3",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.4",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.5",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.6",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.7",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.8",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.9",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.10",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.11",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.2.12",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.3.0",
       "latest": "on",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.3.1",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "8.3.2",
+      "latest": "off",
+      "disable": "off",
+      "xdebug": "on"
+    },
+    {
+      "version": "8.3.3",
+      "latest": "off",
+      "disable": "off",
+      "xdebug": "on"
+    },
+    {
+      "version": "8.3.4",
       "latest": "on",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     }
   ]

--- a/matrix.json
+++ b/matrix.json
@@ -9,139 +9,139 @@
     {
       "version": "7.4.12",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "7.4.33",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.0.15",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.0.27",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.0.29",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.1.6",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.1.11",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.1.13",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.1.20",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.0",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.1",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.2",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.3",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.4",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.5",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.6",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.7",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.8",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.9",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.10",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.11",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.2.12",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "off"
     },
     {
       "version": "8.3.0",
       "latest": "on",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {

--- a/matrix.json
+++ b/matrix.json
@@ -3,157 +3,157 @@
     {
       "version": "5.6.40",
       "latest": "off",
-      "disable": "on",
+      "disable": "off",
       "xdebug": "on"
     },
     {
       "version": "7.4.12",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "7.4.33",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.0.15",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.0.27",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.0.29",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.1.6",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.1.11",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.1.13",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.1.20",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.0",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.1",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.2",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.3",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.4",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.5",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.6",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.7",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.8",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.9",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.10",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.11",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.2.12",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.3.0",
       "latest": "on",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.3.1",
       "latest": "off",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     },
     {
       "version": "8.3.2",
       "latest": "on",
-      "disable": "off",
+      "disable": "on",
       "xdebug": "on"
     }
   ]

--- a/matrix.json
+++ b/matrix.json
@@ -4,139 +4,139 @@
       "version": "5.6.40",
       "latest": "off",
       "disable": "on",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "7.4.12",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "7.4.33",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.0.15",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.0.27",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.0.29",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.1.6",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.1.11",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.1.13",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.1.20",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.0",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.1",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.2",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.3",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.4",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.5",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.6",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.7",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.8",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.9",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.10",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.11",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.2.12",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.3.0",
@@ -148,13 +148,13 @@
       "version": "8.3.1",
       "latest": "off",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     },
     {
       "version": "8.3.2",
       "latest": "on",
       "disable": "off",
-      "xdebug": "off"
+      "xdebug": "on"
     }
   ]
 }

--- a/matrix.json
+++ b/matrix.json
@@ -146,6 +146,12 @@
     },
     {
       "version": "8.3.1",
+      "latest": "off",
+      "disable": "off",
+      "xdebug": "off"
+    },
+    {
+      "version": "8.3.2",
       "latest": "on",
       "disable": "off",
       "xdebug": "off"


### PR DESCRIPTION
seperation from wordpress / symfony and xdebug
Add support PHP 8.3.2, 8.3.3, 8.3.4

Example for PHP 8.3.1 : 

- koromerzhin/php:8.3.1-fpm
- koromerzhin/php:8.3.1-fpm-wordpress
- koromerzhin/php:8.3.1-fpm-symfony
- koromerzhin/php:8.3.1-fpm-xdebug
- koromerzhin/php:8.3.1-fpm-wordpress-xdebug
- koromerzhin/php:8.3.1-fpm-symfony-xdebug
- koromerzhin/php:8.3.1-apache
- koromerzhin/php:8.3.1-apache-wordpress
- koromerzhin/php:8.3.1-apache-symfony
- koromerzhin/php:8.3.1-apache-xdebug
- koromerzhin/php:8.3.1-apache-wordpress-xdebug
- koromerzhin/php:8.3.1-apache-symfony-xdebug